### PR TITLE
fix GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           format: YYYYMMDDHHmmss
       - name: Setup ENV
-        run: echo "name=TAG::$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
+        run: echo ::set-env name=TAG::$(echo ${GITHUB_REF:10})
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Assemble Artifacts with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           format: YYYYMMDDHHmmss
       - name: Setup ENV
-        run: echo ::set-env name=TAG::$(echo ${GITHUB_REF:10})
+        run: echo "TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Assemble Artifacts with Gradle
@@ -32,5 +32,5 @@ jobs:
         uses: AButler/upload-release-assets@v2.0
         with:
           release-tag: ${{ env.TAG }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
           files: 'build/libs/*[!-dev].jar'


### PR DESCRIPTION
This reverts commit 386ad0384fc1c87476e5cf8b0dd20d9390ee59c1.

Fix according to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands